### PR TITLE
fix: reviewers 그룹 이름 변경

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -6,7 +6,8 @@ addAssignees: author
 
 # A list of team reviewers to be added to pull requests (GitHub team slug)
 reviewers:
-  - VA-10S/vafront
+  - Vafront
+  - @vafront
 
 # Number of reviewers has no impact on Github teams
 # Set 0 to add all the reviewers (default: 0)


### PR DESCRIPTION
리뷰 그룹 네이밍을 수정합니다
![image](https://user-images.githubusercontent.com/39752259/187078243-8c85e25f-38e5-4e45-8c00-0f6bfaba4377.png)
